### PR TITLE
Adding evaluation of properties as optional in patch options. Adding …

### DIFF
--- a/Patchable.csproj
+++ b/Patchable.csproj
@@ -4,9 +4,9 @@
     <TargetFrameworks>netstandard21</TargetFrameworks>
     <PackageId>Patchable</PackageId>
     <Description>Enables easy patch (partial changes) without using JsonPatch for ASP.NET and ASP.NET Core.</Description>
-    <Version>1.0.2</Version>
-    <AssemblyVersion>1.0.2.0</AssemblyVersion>
-    <FileVersion>1.0.2.0</FileVersion>
+    <Version>1.0.5</Version>
+    <AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <FileVersion>1.0.5.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/cloudfy/Patchable/blob/main/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/cloudfy/Patchable</PackageProjectUrl>

--- a/PatchableOptions.cs
+++ b/PatchableOptions.cs
@@ -1,5 +1,10 @@
-﻿namespace Patchable
+﻿using System;
+using System.Reflection;
+
+namespace Patchable
 {
+    public delegate void EvaluatePropertyEventHandler(PropertyInfo propertyInfo, object entity, Type entityType);
+
     public sealed class PatchableOptions
     {
         public PatchableOptions(bool ignoreInvalidProperties)
@@ -8,5 +13,27 @@
         }
 
         public bool IgnoreInvalidProperties { get; }
+
+        public event EvaluatePropertyEventHandler EvaluateProperty;
+        internal void OnEvaluateProperty<TEntity>(EvaluatePropertyEventArgs<TEntity> e)
+        {
+            EvaluateProperty?.Invoke(e.PropertyInfo, e.Entity, typeof(TEntity));
+        }
+    }
+
+    public class EvaluatePropertyEventArgs<TEntity> : EventArgs
+    {
+        private PatchablePropInfo _property;
+        private TEntity _entity;
+
+        internal EvaluatePropertyEventArgs(PatchablePropInfo property, TEntity entity)
+        {
+            _property = property;
+            _entity = entity;
+        }
+
+        public bool IgnoreProperty { get; set; }
+        public PropertyInfo PropertyInfo => _property.Property;
+        public TEntity Entity => _entity;
     }
 }


### PR DESCRIPTION
- Adding evaluation of properties as optional in patch options. 
- Adding possibility to patch a target object not reflecting the root.